### PR TITLE
Add better error reporting to CLI and safer deserialization

### DIFF
--- a/src/jokes/joke.py
+++ b/src/jokes/joke.py
@@ -1,19 +1,85 @@
+from dataclasses import dataclass
 from typing import Any
 from jokes.options import Type
+from returns.maybe import Maybe
 
 
+@dataclass
 class Joke:
-    def __init__(self, data: dict[str, Any]) -> None:
-        self.type = data.get("type", "")
-        self.error = data.get("error", False)
-        self.joke = data.get("joke", "")
-        self.setup = data.get("setup", "")
-        self.delivery = data.get("delivery", "")
-        self.category = data.get("category", "")
+    type: str | None
+    joke: Maybe[str]
+    setup: Maybe[str]
+    delivery: Maybe[str]
+    category: Maybe[str]
+    error: "JokeError"
+
+    @staticmethod
+    def create(data: dict[str, Any]) -> "Joke":
+        return Joke(
+            type = data.get("type", None),
+            joke = Maybe.from_optional(data.get("joke")),
+            setup = Maybe.from_optional(data.get("setup")),
+            delivery = Maybe.from_optional(data.get("delivery")),
+            category = Maybe.from_optional(data.get("category")),
+            error = JokeError.create(data)
+        )
 
     def __repr__(self) -> str:
         if self.type == Type.SINGLE.name.lower():
-            return self.joke
+            return self.joke.unwrap()
         if self.type == Type.TWOPART.name.lower():
-            return "\n".join([self.setup, self.delivery])
-        return f"No type matched the given type: {self.type}"
+            return Maybe.do(
+                "\n".join([s, d])
+                for s in self.setup
+                for d in self.delivery
+            ).unwrap()
+        return self.error.error()
+
+
+@dataclass
+class JokeError:
+    internalError: bool
+    message: Maybe[str]
+    causedBy: Maybe[list[str]]
+    additionalInfo: Maybe[str]
+
+    @staticmethod
+    def create(data: dict[str, Any]) -> "JokeError":
+        return JokeError(
+            internalError = data.get("internalError", False),
+            message = Maybe.from_optional(data.get("message")),
+            causedBy = Maybe.from_optional(data.get("causedBy")),
+            additionalInfo = Maybe.from_optional(data.get("additionalInfo"))
+        )
+
+    def error(self) -> str:
+        """
+        Returns an error message depending on the existing values.
+        Internal errors are checked first. If there are no Joke API
+        internal errors, it will attempt to combine the errors included
+        in the `causedBy` field. If that field is empty, it will try
+        the `message` field. And finally, if that field is empty, it
+        will display a custom error message.
+        """
+        if self.internalError:
+            return "An internal JokeAPI error occurred"
+
+        return self.get_basic_error().value_or("An unexpected error occurred.")
+
+
+    def get_basic_error(self) -> Maybe[str]:
+        return (
+            self.causedBy
+            .map(lambda errors: "\n".join(errors))
+            .lash(lambda _: self.message)
+        )
+
+
+    # TODO: Need a way to reach this bit of code.
+    def get_debug_error(self) -> Maybe[str]:
+        return Maybe.do(
+            "\n".join([message, *errors, additional])
+            for message in self.message
+            for errors in self.causedBy
+            for additional in self.additionalInfo
+        )

--- a/src/jokes/request.py
+++ b/src/jokes/request.py
@@ -31,12 +31,10 @@ def _make_request(data: OptionData) -> Response:
 
 @safe
 def _deserialize(response: Response) -> Joke:
-    return Joke(response.json())
+    return Joke.create(response.json())
 
 
 @safe
 def _get_content(joke: Joke) -> str:
-    if joke.error:
-        return "An unexpected error occurred."
     return str(joke)
     

--- a/tests/jokes/test_joke.py
+++ b/tests/jokes/test_joke.py
@@ -1,0 +1,108 @@
+import pytest
+
+from typing import Any
+from jokes.joke import Joke
+from returns.maybe import Some, Nothing
+
+
+class TestJoke:
+    @pytest.fixture
+    def valid_single_data(self) -> dict[str, Any]:
+        return {
+            'error': False,
+            'category': 'Dark',
+            'type': 'single',
+            'joke': "Some funny joke.",
+            'flags': {
+                'nsfw': False,
+                'religious': False,
+                'political': False,
+                'racist': False,
+                'sexist': False,
+                'explicit': False
+            }
+        }
+
+
+    @pytest.fixture
+    def valid_twopart_data(self) -> dict[str, Any]:
+        return {
+            'error': False,
+            'category': 'Dark',
+            'type': 'twopart',
+            'setup': "Why did the chicken cross the road?",
+            'delivery': "To get to the other side.",
+            'flags': {
+                'nsfw': False,
+                'religious': False,
+                'political': False,
+                'racist': False,
+                'sexist': False,
+                'explicit': False
+            }
+        }
+
+
+    @pytest.fixture
+    def valid_error_data(self) -> dict[str, Any]:
+        return {
+            'error': True,
+            'internalError': False,
+            'message': 'No matching joke found',
+            'causedBy': ['No jokes were found that match your provided filter(s)'],
+            'additionalInfo': 'The specified ID range was out of boungs.'
+        }
+
+
+    def test_single_joke_success(self, valid_single_data: dict[str, Any]):
+        joke = Joke.create(valid_single_data)
+
+        assert joke.type == valid_single_data["type"]
+        assert joke.category == Some(valid_single_data["category"])
+        assert joke.joke == Some(valid_single_data["joke"])
+        assert joke.delivery == Nothing
+        assert joke.setup == Nothing
+        assert str(joke) == valid_single_data["joke"]
+
+
+    def test_twopart_joke_success(self, valid_twopart_data: dict[str, Any]):
+        joke = Joke.create(valid_twopart_data)
+        setup = valid_twopart_data["setup"]
+        delivery = valid_twopart_data["delivery"]
+
+        assert joke.type == valid_twopart_data["type"]
+        assert joke.category == Some(valid_twopart_data["category"])
+        assert joke.joke == Nothing
+        assert joke.delivery == Some(valid_twopart_data["delivery"])
+        assert joke.setup == Some(valid_twopart_data["setup"])
+        assert str(joke) == "\n".join([setup, delivery])
+
+
+    def test_error_success(self, valid_error_data: dict[str, Any]):
+        joke = Joke.create(valid_error_data)
+
+        assert joke.type == None
+        assert joke.category == Nothing
+        assert joke.joke == Nothing
+        assert joke.delivery == Nothing
+        assert joke.setup == Nothing
+        assert joke.error.message == Some(valid_error_data["message"])
+        assert joke.error.additionalInfo == Some(valid_error_data["additionalInfo"])
+        assert joke.error.causedBy == Some(valid_error_data["causedBy"])
+        assert joke.error.internalError == valid_error_data["internalError"]
+        assert str(joke) == "\n".join(valid_error_data["causedBy"])
+
+
+    def test_joke_invalid_data(self):
+        joke = Joke.create({})
+
+        assert joke.type == None
+        assert joke.category == Nothing
+        assert joke.joke == Nothing
+        assert joke.delivery == Nothing
+        assert joke.setup == Nothing
+        assert joke.error.internalError == False
+        assert joke.error.additionalInfo == Nothing
+        assert joke.error.causedBy == Nothing
+        assert joke.error.message == Nothing
+        assert str(joke) == "An unexpected error occurred."

--- a/tests/jokes/test_request.py
+++ b/tests/jokes/test_request.py
@@ -3,6 +3,7 @@ import pytest
 from jokes.options import OptionData, Type, Flag, Category
 from jokes.request import _make_request, _deserialize
 from returns.unsafe import unsafe_perform_io
+from returns.maybe import Nothing
 
 
 class TestRequest:
@@ -15,7 +16,10 @@ class TestRequest:
         response = unsafe_perform_io(_make_request(data).bind_result(_deserialize).unwrap())
 
         assert response.type == type.name.lower()
-        assert response.error == False
+        assert response.error.internalError == False
+        assert response.error.message == Nothing
+        assert response.error.causedBy == Nothing
+        assert response.error.additionalInfo == Nothing
 
 
     @staticmethod


### PR DESCRIPTION
- Provides safer deserialization using the `returns` library and some "functional" approaches.
- Returns more detailed error responses (still needs to connect the debug error to the use of the `--debug` flag)
- Adds basic tests for the deserialization classes