### PR TITLE
Safer joke to string

### DIFF
--- a/src/jokes/joke.py
+++ b/src/jokes/joke.py
@@ -37,17 +37,13 @@ class Joke:
             error = JokeError.create(data)
         )
 
-      
-    def get_joke_string(self) -> Maybe[str]:
-        """
-        Gets the joke based on the type. If there
-        is no type, or no type matches, returns `Nothing`.
-        """
-        return self.type.bind(lambda type: self.joke_by_type.get(type, Maybe.empty))
-
 
     def __repr__(self) -> str:
-        return self.get_joke_string().value_or(self.error.error())
+        return (
+            self.type
+            .bind(lambda type: self.joke_by_type.get(type, Maybe.empty))
+            .value_or(self.error.error())
+        )
 
 
 @dataclass

--- a/src/jokes/joke.py
+++ b/src/jokes/joke.py
@@ -6,17 +6,30 @@ from returns.maybe import Maybe
 
 @dataclass
 class Joke:
-    type: str | None
+    type: Maybe[str]
     joke: Maybe[str]
     setup: Maybe[str]
     delivery: Maybe[str]
     category: Maybe[str]
     error: "JokeError"
 
+
+    @property
+    def joke_by_type(self) -> dict[str, Maybe[str]]:
+        return {
+            Type.SINGLE.name.lower(): self.joke,
+            Type.TWOPART.name.lower(): Maybe.do(
+                "\n".join([s, d])
+                for s in self.setup
+                for d in self.delivery
+            )
+        }
+
+
     @staticmethod
     def create(data: dict[str, Any]) -> "Joke":
         return Joke(
-            type = data.get("type", None),
+            type = Maybe.from_optional(data.get("type")),
             joke = Maybe.from_optional(data.get("joke")),
             setup = Maybe.from_optional(data.get("setup")),
             delivery = Maybe.from_optional(data.get("delivery")),
@@ -24,16 +37,17 @@ class Joke:
             error = JokeError.create(data)
         )
 
+      
+    def get_joke_string(self) -> Maybe[str]:
+        """
+        Gets the joke based on the type. If there
+        is no type, or no type matches, returns `Nothing`.
+        """
+        return self.type.bind(lambda type: self.joke_by_type.get(type, Maybe.empty))
+
+
     def __repr__(self) -> str:
-        if self.type == Type.SINGLE.name.lower():
-            return self.joke.unwrap()
-        if self.type == Type.TWOPART.name.lower():
-            return Maybe.do(
-                "\n".join([s, d])
-                for s in self.setup
-                for d in self.delivery
-            ).unwrap()
-        return self.error.error()
+        return self.get_joke_string().value_or(self.error.error())
 
 
 @dataclass
@@ -43,6 +57,7 @@ class JokeError:
     causedBy: Maybe[list[str]]
     additionalInfo: Maybe[str]
 
+
     @staticmethod
     def create(data: dict[str, Any]) -> "JokeError":
         return JokeError(
@@ -51,6 +66,7 @@ class JokeError:
             causedBy = Maybe.from_optional(data.get("causedBy")),
             additionalInfo = Maybe.from_optional(data.get("additionalInfo"))
         )
+
 
     def error(self) -> str:
         """
@@ -68,6 +84,12 @@ class JokeError:
 
 
     def get_basic_error(self) -> Maybe[str]:
+        """
+        Gets the error when debug is set to false,
+        which is the returned `causedBy` message. If
+        that message does not exist, returns the base
+        `message`. Otherwise returns `Nothing`.
+        """
         return (
             self.causedBy
             .map(lambda errors: "\n".join(errors))
@@ -77,6 +99,12 @@ class JokeError:
 
     # TODO: Need a way to reach this bit of code.
     def get_debug_error(self) -> Maybe[str]:
+        """
+        Gets the error when debug is set to true,
+        which is a combined version of all fields in
+        the json response.
+        Otherwise returns `Nothing`.
+        """
         return Maybe.do(
             "\n".join([message, *errors, additional])
             for message in self.message

--- a/tests/jokes/test_joke.py
+++ b/tests/jokes/test_joke.py
@@ -57,7 +57,7 @@ class TestJoke:
     def test_single_joke_success(self, valid_single_data: dict[str, Any]):
         joke = Joke.create(valid_single_data)
 
-        assert joke.type == valid_single_data["type"]
+        assert joke.type == Some(valid_single_data["type"])
         assert joke.category == Some(valid_single_data["category"])
         assert joke.joke == Some(valid_single_data["joke"])
         assert joke.delivery == Nothing
@@ -70,7 +70,7 @@ class TestJoke:
         setup = valid_twopart_data["setup"]
         delivery = valid_twopart_data["delivery"]
 
-        assert joke.type == valid_twopart_data["type"]
+        assert joke.type == Some(valid_twopart_data["type"])
         assert joke.category == Some(valid_twopart_data["category"])
         assert joke.joke == Nothing
         assert joke.delivery == Some(valid_twopart_data["delivery"])
@@ -81,7 +81,7 @@ class TestJoke:
     def test_error_success(self, valid_error_data: dict[str, Any]):
         joke = Joke.create(valid_error_data)
 
-        assert joke.type == None
+        assert joke.type == Nothing
         assert joke.category == Nothing
         assert joke.joke == Nothing
         assert joke.delivery == Nothing
@@ -96,7 +96,7 @@ class TestJoke:
     def test_joke_invalid_data(self):
         joke = Joke.create({})
 
-        assert joke.type == None
+        assert joke.type == Nothing
         assert joke.category == Nothing
         assert joke.joke == Nothing
         assert joke.delivery == Nothing

--- a/tests/jokes/test_request.py
+++ b/tests/jokes/test_request.py
@@ -3,7 +3,7 @@ import pytest
 from jokes.options import OptionData, Type, Flag, Category
 from jokes.request import _make_request, _deserialize
 from returns.unsafe import unsafe_perform_io
-from returns.maybe import Nothing
+from returns.maybe import Some, Nothing
 
 
 class TestRequest:
@@ -15,7 +15,7 @@ class TestRequest:
         data = self._create_option_data(type=type)
         response = unsafe_perform_io(_make_request(data).bind_result(_deserialize).unwrap())
 
-        assert response.type == type.name.lower()
+        assert response.type == Some(type.name.lower())
         assert response.error.internalError == False
         assert response.error.message == Nothing
         assert response.error.causedBy == Nothing


### PR DESCRIPTION
The `__repr__` method in `Joke` was calling `unwrap` internally, which is fine since we're calling it within a `@safe` method. However, what happens if we don't call it within a safe method? It throws an unwrap exception if the inner joke doesn't exist. This is unlikely to happen, but can happen.

- Made the type property a `Maybe`
- Move the if statements to a dictionary based on [some wise man's advice](https://www.youtube.com/shorts/psu7LYIyQAo)
- Safely use `bind` on the type to try to get the inner joke from the dictionary, otherwise returns the error as normal
- Added some docstrings for good measure