### PR TITLE
Added submit command

### DIFF
--- a/src/jokes/app.py
+++ b/src/jokes/app.py
@@ -2,7 +2,7 @@ import click
 
 from jokes.options import Type, Flag, Category, OptionData, as_list
 from jokes.request import get_joke
-from jokes.requests.submit import submit_joke, JokeSubmitData
+from jokes.requests.submit import submit_joke, SubmitJokeData
 from returns.unsafe import unsafe_perform_io
 from returns.functions import raise_exception
 from returns.io import IOResultE, IO
@@ -73,7 +73,11 @@ def get(ctx: Context, category: str, type: str, flags: list[str]) -> None:
 @click.pass_context
 def submit(ctx: Context, category: str, type: str, flags: list[str]) -> None:
     flags_as_dict = {f.lower(): True for f in flags}
-    joke = JokeSubmitData(
+
+    # Use SubmitJokeData instead of SubmitJoke to delay validation.
+    # We don't want validation errors to appear on the screen immediately
+    # or without debug.
+    joke = SubmitJokeData(
         type=type,
         category=category,
         flags=flags_as_dict

--- a/src/jokes/app.py
+++ b/src/jokes/app.py
@@ -2,8 +2,10 @@ import click
 
 from jokes.options import Type, Flag, Category, OptionData, as_list
 from jokes.request import get_joke
+from jokes.requests.submit import submit_joke, JokeSubmitData
 from returns.unsafe import unsafe_perform_io
 from returns.functions import raise_exception
+from returns.io import IOResultE, IO
 from click.core import Context
 
 
@@ -43,9 +45,52 @@ def jokes(ctx: Context, debug: bool):
 def get(ctx: Context, category: str, type: str, flags: list[str]) -> None:
     joke = get_joke(OptionData(category, type, flags))
 
-    if ctx.obj.get("DEBUG", False):
-        result = joke.alt(raise_exception).unwrap()
-    else:
-        result = joke.value_or("An unexpected error occurred.")
+    click.echo(unsafe_perform_io(unwrap(ctx, joke)))
 
-    click.echo(unsafe_perform_io(result))
+
+# Turned off for now since the api is not allowing submissions at the moment
+# @jokes.command()
+@click.option(
+    "-c", "--category", "category",
+    type=click.Choice(as_list(Category)[1:], case_sensitive=False),
+    required=True
+)
+@click.option(
+    "-t", "--type", "type",
+    type=click.Choice(as_list(Type), case_sensitive=False),
+    required=True
+)
+@click.option(
+    "-f", "--flag", "flags",
+    multiple=True,
+    type=click.Choice(as_list(Flag), case_sensitive=False),
+    help="""
+        Can be used several times to mark any flags that may pertain to your joke.\n
+        E.g. 'jokes -f nsfw -f explicit' tells the API that the joke is nsfw and explicit.
+    """,
+    default=[]
+)
+@click.pass_context
+def submit(ctx: Context, category: str, type: str, flags: list[str]) -> None:
+    flags_as_dict = {f.lower(): True for f in flags}
+    joke = JokeSubmitData(
+        type=type,
+        category=category,
+        flags=flags_as_dict
+    )
+
+    if type == Type.TWOPART.name:
+        joke.setup = click.prompt("Joke setup", type=str)
+        joke.delivery = click.prompt("Joke delivery", type=str)
+
+    elif type == Type.SINGLE.name:
+        joke.joke = click.prompt("Joke", type=str)
+
+    click.echo(unsafe_perform_io(unwrap(ctx, submit_joke(joke))))
+
+
+def unwrap(ctx: Context, result: IOResultE) -> IO:
+    if ctx.obj.get("DEBUG", False):
+        return result.alt(raise_exception).unwrap()
+    else:
+        return result.value_or("An unexpected error occurred.")

--- a/src/jokes/models/flags.py
+++ b/src/jokes/models/flags.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class Flags(BaseModel):
+    nsfw: bool = False
+    religious: bool = False
+    political: bool = False
+    racist: bool = False
+    sexist: bool = False
+    explicit: bool = False

--- a/src/jokes/models/joke.py
+++ b/src/jokes/models/joke.py
@@ -71,5 +71,5 @@ class SubmitJoke(Joke):
     flags: Flags
 
 
-class SubmittedJokeResponse(BaseModel):
+class SubmittedJoke(BaseModel):
     message: str

--- a/src/jokes/models/joke.py
+++ b/src/jokes/models/joke.py
@@ -1,4 +1,5 @@
 from jokes.options import Type
+from jokes.models.flags import Flags
 from pydantic import validator, BaseModel
 from returns.maybe import Maybe
 
@@ -62,3 +63,9 @@ class Joke(BaseModel):
             self.joke_by_type.get(self.type, Maybe.empty)
             .value_or(f"Could not find joke with type: '{self.type}'.")
         )
+
+
+class SubmitJoke(Joke):
+    formatVersion: int = 3
+    lang: str = "en"
+    flags: Flags

--- a/src/jokes/models/joke.py
+++ b/src/jokes/models/joke.py
@@ -69,3 +69,7 @@ class SubmitJoke(Joke):
     formatVersion: int = 3
     lang: str = "en"
     flags: Flags
+
+
+class SubmittedJokeResponse(BaseModel):
+    message: str

--- a/src/jokes/requests/submit.py
+++ b/src/jokes/requests/submit.py
@@ -4,7 +4,7 @@ from returns.io import IOResultE, impure_safe
 from returns.result import safe
 from returns.pipeline import flow
 from returns.pointfree import bind_ioresult, bind_result
-from jokes.models.joke import SubmitJoke, SubmittedJokeResponse
+from jokes.models.joke import SubmitJoke, SubmittedJoke
 from jokes.models.error import Error
 
 
@@ -42,6 +42,6 @@ def submit_request(data: str) -> Response:
 
 
 @safe
-def deserialize_response(response: Response) -> SubmittedJokeResponse | Error:
+def deserialize_response(response: Response) -> SubmittedJoke | Error:
     response_as_json = response.json()
-    return SubmittedJokeResponse(**response_as_json) if not response_as_json["error"] else Error(**response_as_json)
+    return SubmittedJoke(**response_as_json) if not response_as_json["error"] else Error(**response_as_json)

--- a/src/jokes/requests/submit.py
+++ b/src/jokes/requests/submit.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from httpx import Response, Client
+from returns.io import IOResultE, impure_safe
+from returns.result import safe
+from returns.pipeline import flow
+from returns.pointfree import bind_ioresult
+from jokes.models.joke import SubmitJoke
+from jokes.models.error import Error
+
+
+@dataclass
+class JokeSubmitData:
+    type: str
+    category: str
+    flags: dict[str, bool]
+    joke: str | None = None
+    setup: str | None = None
+    delivery: str | None = None
+
+
+def submit_joke(data: JokeSubmitData) -> IOResultE[Response]:
+    return flow(
+        data,
+        make_joke,
+        bind_ioresult(submit_request)
+    )
+
+
+@impure_safe
+def make_joke(data: JokeSubmitData) -> str:
+    return SubmitJoke(**data.__dict__).json(exclude_none=True)
+
+
+@impure_safe
+def submit_request(data: str) -> Response:
+    with Client() as client:
+        response = client.post("https://v2.jokeapi.dev/submit?dry-run", json=data)
+        response.raise_for_status()
+
+        return response
+
+@safe
+def deserialize_response(response: Response) -> Error:
+    return Error(**response.json())

--- a/src/jokes/requests/submit.py
+++ b/src/jokes/requests/submit.py
@@ -9,7 +9,7 @@ from jokes.models.error import Error
 
 
 @dataclass
-class JokeSubmitData:
+class SubmitJokeData:
     type: str
     category: str
     flags: dict[str, bool]
@@ -18,7 +18,7 @@ class JokeSubmitData:
     delivery: str | None = None
 
 
-def submit_joke(data: JokeSubmitData) -> IOResultE[Response]:
+def submit_joke(data: SubmitJokeData) -> IOResultE[Response]:
     return flow(
         data,
         make_joke,
@@ -28,7 +28,7 @@ def submit_joke(data: JokeSubmitData) -> IOResultE[Response]:
 
 
 @impure_safe
-def make_joke(data: JokeSubmitData) -> str:
+def make_joke(data: SubmitJokeData) -> str:
     return SubmitJoke(**data.__dict__).json(exclude_none=True)
 
 


### PR DESCRIPTION
Part 2 to #6 

Adds a submit command to the joke CLI.

Unfortunately it is still a work in progress since the API is not accepting new jokes.

![image](https://user-images.githubusercontent.com/39095798/181036431-c97325dc-356e-46a7-8ffc-1d8023549533.png)

I've commented out the command so that it cannot be accessed from the CLI. More work will need to be done in the `submit.py` file once the endpoint comes back online.

There is a feature which will need to be added:

1. The endpoint should allow for the use of the api's `dry-run` when testing/debugging. This will ensure that the submitted joke is not saved to the API.

