### PR TITLE
Add random default type to get command

### DIFF
--- a/src/jokes/app.py
+++ b/src/jokes/app.py
@@ -1,4 +1,5 @@
 import click
+import random
 
 from types import SimpleNamespace
 from jokes.options import Type, Flag, Category, OptionData, as_list
@@ -29,8 +30,8 @@ def jokes(ctx: Context, debug: bool):
 )
 @click.option(
     "-t", "--type", "type",
-    type=click.Choice(as_list(Type), case_sensitive=False),
-    default=Type.SINGLE.name
+    type=click.Choice(type_list := as_list(Type), case_sensitive=False),
+    default=random.choice(type_list)
 )
 @click.option(
     "-f", "--flag", "flags",


### PR DESCRIPTION
The get command used `SINGLE` as its default. In order to get a `TWOPART` joke you had to manually add the option `--type twopart`. 

Now the get command will choose a random type (either single or twopart) and return the result.