### PR TITLE
Refactor joke models

### DIFF
--- a/src/jokes/models/__init__.py
+++ b/src/jokes/models/__init__.py
@@ -1,0 +1,16 @@
+from .joke import (
+    JokeBase,
+    JokeSingle,
+    JokeTwopart,
+    JokeSubmit,
+    JokeSingleSubmit,
+    JokeTwopartSubmit,
+    JokeSubmitted
+)
+from .error import Error
+from .flags import Flags
+
+Joke = JokeSingle | JokeTwopart
+JokeE = Joke | Error
+SubmitJoke = JokeSingleSubmit | JokeTwopartSubmit
+SubmittedJokeE = JokeSubmitted | Error

--- a/src/jokes/models/error.py
+++ b/src/jokes/models/error.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 from click import get_current_context
 from click.core import Context
-from returns.maybe import maybe
 
 
 class Error(BaseModel):
@@ -19,14 +18,9 @@ class Error(BaseModel):
         the thread nor the value exist, returns
         False.
         """
-        return (
-            self.get_context()
-            .map(lambda ctx: ctx.obj.get("DEBUG"))
-            .value_or(False)
-        )
+        return context.obj.get("DEBUG") if (context := self.get_context()) else False
 
 
-    @maybe
     def get_context(self) -> Context | None:
         """
         Gets the current thread's context. If no
@@ -36,28 +30,17 @@ class Error(BaseModel):
         return get_current_context(silent=True)
 
 
-    def get_basic_error(self) -> str:
-        """
-        Meant to be the error when 'Debug' is set
-        to 'False'.
-        Simply formats and returns the 'causedBy' error. 
-        """
-        return "\n".join(self.causedBy)
-
-
-    def get_exhaustive_error(self) -> str:
-        """
-        Meant to be the error when 'Debug' is set
-        to 'True'.
-        Returns a formatted string of all error types
-        present in the response.
-        """
-        return "\n".join([self.message, *self.causedBy, self.additionalInfo])
-
-
     def as_string(self) -> str:
-        if self.internalError:
-            return "An internal JokeAPI error occurred"
+        return str(self)
 
-        return self.get_exhaustive_error() if self.debug else self.get_basic_error()
+
+    def __str__(self) -> str:
+        """Returns a string representation of the error class."""
+
+        if self.internalError:
+            return "An internal JokeAPI error occurred."
+
+        match self.debug:
+            case True: return "\n".join([self.message, *self.causedBy, self.additionalInfo])
+            case False: return "\n".join(self.causedBy)
 

--- a/src/jokes/models/error.py
+++ b/src/jokes/models/error.py
@@ -30,10 +30,6 @@ class Error(BaseModel):
         return get_current_context(silent=True)
 
 
-    def as_string(self) -> str:
-        return str(self)
-
-
     def __str__(self) -> str:
         """Returns a string representation of the error class."""
 

--- a/tests/jokes/test_joke.py
+++ b/tests/jokes/test_joke.py
@@ -3,10 +3,19 @@ import string
 import typing
 
 from types import SimpleNamespace
-from jokes.options import Category, Type
-from jokes.models.joke import Joke, SubmitJoke
-from jokes.models.error import Error
 from pydantic import ValidationError
+from jokes.options import Category, Type
+from jokes.models import (
+    JokeBase,
+    JokeSubmit,
+    JokeSingle,
+    JokeTwopart,
+    JokeSingleSubmit,
+    JokeTwopartSubmit,
+    JokeSubmitted,
+    Error
+)
+
 
 
 class TestJoke:
@@ -65,28 +74,27 @@ class TestJoke:
         }
 
 
-    def test_single_joke_success(self, valid_single_joke_get_response: dict[str, typing.Any]):
-        joke = Joke(**valid_single_joke_get_response)
+    def test_joke_base_includes_all_data(self, valid_single_joke_get_response: dict[str, typing.Any]):
+        joke = JokeBase(**valid_single_joke_get_response)
 
-        assert joke.type == valid_single_joke_get_response["type"]
-        assert joke.category == valid_single_joke_get_response["category"]
+        assert joke.dict() == valid_single_joke_get_response
+
+
+    def test_single_joke_success(self, valid_single_joke_get_response: dict[str, typing.Any]):
+        joke = JokeSingle(**valid_single_joke_get_response)
+
         assert joke.joke == valid_single_joke_get_response["joke"]
-        assert joke.delivery == None
-        assert joke.setup == None
-        assert joke.as_string() == valid_single_joke_get_response["joke"]
+        assert str(joke) == valid_single_joke_get_response["joke"]
 
 
     def test_twopart_joke_success(self, valid_twopart_joke_get_response: dict[str, typing.Any]):
-        joke = Joke(**valid_twopart_joke_get_response)
+        joke = JokeTwopart(**valid_twopart_joke_get_response)
         setup = valid_twopart_joke_get_response["setup"]
         delivery = valid_twopart_joke_get_response["delivery"]
 
-        assert joke.type == valid_twopart_joke_get_response["type"]
-        assert joke.category == valid_twopart_joke_get_response["category"]
-        assert joke.joke == None
         assert joke.delivery == delivery
         assert joke.setup == setup
-        assert joke.as_string() == "\n".join([setup, delivery])
+        assert str(joke) == "\n".join([setup, delivery])
 
 
     def test_error_success(self, valid_error_response: dict[str, typing.Any]):
@@ -104,71 +112,38 @@ class TestJoke:
             Error(**{})
 
 
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
+    @pytest.mark.parametrize("joke_class", [
+        JokeSingle,
+        JokeTwopart,
+        JokeBase,
+        JokeSingleSubmit,
+        JokeTwopartSubmit,
+        JokeSubmitted,
+        JokeSubmit
+    ])
     def test_joke_invalid_data(self, joke_class: typing.Type):
-        with pytest.raises(ValidationError) as ex:
+        with pytest.raises(ValidationError):
             joke_class(**{})
 
 
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
+    @pytest.mark.parametrize("joke_class", [JokeTwopart, JokeTwopartSubmit])
     def test_cannot_create_twopart_joke_without_setup_and_delivery(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
         simple_joke_data.type = Type.TWOPART.name
 
-        with pytest.raises(ValidationError) as ex:
+        with pytest.raises(ValidationError):
             joke_class(**simple_joke_data.__dict__)
 
-        assert "Setup field must be included in a twopart joke." in str(ex.value.args)
 
-
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
+    @pytest.mark.parametrize("joke_class", [JokeTwopart, JokeTwopartSubmit])
     def test_cannot_create_twopart_joke_with_setup_but_no_delivery(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
         simple_joke_data.type = Type.TWOPART.name
         simple_joke_data.setup = string.ascii_letters
 
-        with pytest.raises(ValidationError) as ex:
+        with pytest.raises(ValidationError):
             joke_class(**simple_joke_data.__dict__)
 
-        assert "Delivery field must be included in a twopart joke." in str(ex.value.args)
 
-
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
-    def test_cannot_create_twopart_joke_with_joke_field(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
-        simple_joke_data.type = Type.TWOPART.name
-        simple_joke_data.setup = string.ascii_letters
-        simple_joke_data.delivery = string.ascii_letters
-        simple_joke_data.joke = string.ascii_letters
-
-        with pytest.raises(ValidationError) as ex:
-            joke_class(**simple_joke_data.__dict__)
-
-        assert "Joke field cannot be included in a twopart joke." in str(ex.value.args)
-
-
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
+    @pytest.mark.parametrize("joke_class", [JokeSingle, JokeSingleSubmit])
     def test_cannot_create_single_joke_without_joke_field(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
-        with pytest.raises(ValidationError) as ex:
+        with pytest.raises(ValidationError):
             joke_class(**simple_joke_data.__dict__)
-
-        assert "Joke field must be included in a single joke." in str(ex.value.args)
-
-
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
-    def test_cannot_create_single_joke_with_setup_field(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
-        simple_joke_data.joke = string.ascii_letters
-        simple_joke_data.setup = string.ascii_letters
-
-        with pytest.raises(ValidationError) as ex:
-            joke_class(**simple_joke_data.__dict__)
-
-        assert "Setup field cannot be included in a single joke." in str(ex.value.args)
-
-
-    @pytest.mark.parametrize("joke_class", [Joke, SubmitJoke])
-    def test_cannot_create_single_joke_with_delivery_field(self, joke_class: typing.Type, simple_joke_data: SimpleNamespace):
-        simple_joke_data.joke = string.ascii_letters
-        simple_joke_data.delivery = string.ascii_letters
-
-        with pytest.raises(ValidationError) as ex:
-            joke_class(**simple_joke_data.__dict__)
-
-        assert "Delivery field cannot be included in a single joke." in str(ex.value.args)

--- a/tests/jokes/test_joke.py
+++ b/tests/jokes/test_joke.py
@@ -104,7 +104,7 @@ class TestJoke:
         assert error.additionalInfo == valid_error_response["additionalInfo"]
         assert error.causedBy == valid_error_response["causedBy"]
         assert error.internalError == valid_error_response["internalError"]
-        assert error.as_string() == "\n".join(valid_error_response["causedBy"])
+        assert str(error) == "\n".join(valid_error_response["causedBy"])
 
 
     def test_error_invalid_data(self):

--- a/tests/jokes/test_request.py
+++ b/tests/jokes/test_request.py
@@ -1,5 +1,6 @@
 import pytest
-from jokes.models.joke import Joke
+
+from jokes.models import JokeSingle, JokeTwopart
 from jokes.options import OptionData, Type, Flag, Category
 from jokes.pipelines.get_pipeline import make_request, deserialize
 from returns.unsafe import unsafe_perform_io
@@ -18,11 +19,14 @@ class TestRequest:
         data = self._create_option_data(category, type)
         response = unsafe_perform_io(make_request(data).bind_result(deserialize).unwrap())
 
-        assert isinstance(response, Joke)
-        assert response.type == type.name
-
-        if category != Category.ANY:
-            assert response.category == category.name
+        match type:
+            case Type.SINGLE:
+                assert isinstance(response, JokeSingle)
+                assert response.joke is not None
+            case Type.TWOPART: 
+                assert isinstance(response, JokeTwopart)
+                assert response.setup is not None
+                assert response.delivery is not None
 
 
     @staticmethod


### PR DESCRIPTION
Refactored the joke models and changed the way the models should work in general.

### The Problem

I was using a lot of pattern matching in different places to validate whether the joke was a `SINGLE` type or a `TWOPART` type. This meant that if I were ever to add another joke type, I would have to find and update all of these points of validation logic. Annoying. It also meant the the model was doing a lot more logic that it should be doing. IMO the models should only represent the data, the logic should be included elsewhere. And finally, I wasn't leveraging pydantic to its best, and I included a bunch of tricky logic that could very easily get confusing (if it wasn't already).

### The Solution

Create models that represent the types of jokes, i.e. `SINGLE` and `TWOPART` and use pydantic as the primary validator. 

The previous code used custom validation for each joke type within a pattern matching statement. 

```py
case Type.TWOPART:
    assert setup is not None, "Setup field must be included in a twopart joke."
    assert delivery is not None, "Delivery field must be included in a twopart joke."
    assert joke is None, "Joke field cannot be included in a twopart joke."
```

This meant that if I were to add another type, say `KNOCKKNOCK`, I would have to add more validation into each statement so the above code might look like this:

```py
case Type.TWOPART:
    assert setup is not None, "Setup field must be included in a twopart joke."
    assert delivery is not None, "Delivery field must be included in a twopart joke."
    assert joke is None, "Joke field cannot be included in a twopart joke."
    assert knock_knock_part1 is None, "knock_knock_part1 field cannot be included in a twopart joke."
    assert knock_knock_part2 is None, "knock_knock_part2 field cannot be included in a twopart joke."
    assert knock_knock_part3 is None, "knock_knock_part3 field cannot be included in a twopart joke."
    assert knock_knock_part4 is None, "knock_knock_part4 field cannot be included in a twopart joke."
    assert knock_knock_part5 is None, "knock_knock_part5 field cannot be included in a twopart joke."
```

I would also have to add a case for the knock knock joke type. This is ridiculous and can spiral out of control very quickly.

Luckily pydantic handles field validation for us. So instead of having a single joke class, there can be several that each represent a joke type. That way, when a joke is created, the joke class will have the necessary fields and check that those are present in the creation data.

This translates into

```py
class JokeBase(BaseModel):
    ...

class JokeSingle(BaseModel):
    joke: str

class JokeTwopart(BaseModel):
    setup: str
    delivery: str
```

Not only does this make it clearer what class represents what, it also forces the logic of creating each joke type outside of the base joke class, making it less of a mystery.

And if I wanted to add another joke type it would be as easy as this:

```py
class JokeKnockKnock(BaseModel):
    knock_knock_part1: str
    knock_knock_part2: str
    knock_knock_part3: str
    knock_knock_part4: str
    knock_knock_part5: str
```

No more adding custom validation and tricky logic, and crossing my fingers hoping for the best.

Now, I said the changes force the logic of creating each joke outside the base joke class. This is only partially true. The `JokeBase` class contains a method called `match_type` which will match the validated type and create a joke based on that type. However, the parameters required to call the method ask for functions. So which the match method is inside the base class, the logic of the create methods is still passed outside the class.

Why do this?

Basically there were a few options. One was to create a simple method that took a type, data, and actions to create the classes based on the type. This would have looked something like this:

```py
def match_type(type: Type, data: dict, single_action: Callable[[dict], T1], twopart_action: Callable[[dict], T2]) -> T1 | T2:
    match type:
        case Type.SINGLE: return single_action(data),
        case TYPE.TWOPART: return twopart_action(data),
        case _: raise
```

So similar to what is here, but with more parameters.'

The reason I didn't like this is because it required me to validate the data with the `JokeBase` first then get and convert the type again after validation. So before calling this `match_type` function, I would've had to first call `JokeBase(**data)` then `type = Type[data.get("type").upper()]`. Since `JokeBase` is already validating, storing, and converting the type to uppercase, I felt this was an opportunity to leverage it a bit better. **By adding the extra field in the Config class, I ensure that the data being passed to the base class is being kept intact. This means that `JokeBase(**data).dict() == data`.** Without this extra field, the data not represented by fields in the class is dropped. 

Now I can create my models in a smooth flow of actions. So instead of

```py
JokeBase(**data)
type = Type[data.get("type").upper()]
match_type(
    type=type,
    data=data,
    single_action=lambda d: JokeSingle(**d),
    twopart_action=lambda d: JokeTwopart(**d)
)
```

I now can use

```py
JokeBase(**data).match_type(
    single_action=lambda d: JokeSingle(**d),
    twopart_action=lambda d: JokeTwopart(**d)
)
```

🎉 🥳 